### PR TITLE
Add customizable control scheme dropdown

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -63,4 +63,5 @@ When adding new configuration options, update all relevant places:
 2. Configuration schemas in `src/config/`
 3. Documentation in README.md
 
-All configuration keys use consistent naming and MUST be documented.
+All configuration keys use consistent naming and MUST be documented. Configuration JSON files must
+be imported using import attributes: `with { type: 'json' }`.

--- a/controls.config.json
+++ b/controls.config.json
@@ -1,0 +1,22 @@
+{
+	"schemes": {
+		"wasd": {
+			"up": "KeyW",
+			"left": "KeyA",
+			"down": "KeyS",
+			"right": "KeyD",
+			"pause": "KeyP",
+			"restart": "KeyR",
+			"wrap": "KeyT"
+		},
+		"arrows": {
+			"up": "ArrowUp",
+			"left": "ArrowLeft",
+			"down": "ArrowDown",
+			"right": "ArrowRight",
+			"pause": "KeyP",
+			"restart": "KeyR",
+			"wrap": "KeyT"
+		}
+	}
+}

--- a/index.html
+++ b/index.html
@@ -1,100 +1,119 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Snake — Dark Mode (Canvas)</title>
-  <link rel="stylesheet" href="./styles.css" />
-</head>
-<body>
-  <div class="shell">
-    <div class="card">
-      <header>
-        <h1><span class="dot"></span> Snake</h1>
-        <div class="stats">
-          <button class="info-btn" id="infoHeaderBtn" aria-label="Info">ⓘ</button>
-          <button class="info-btn desktop-only" id="controlsHeaderBtn" aria-label="Controls">⌨</button>
-          <div class="chip">Score: <strong id="score">0</strong></div>
-          <div class="chip">High: <strong id="high">0</strong></div>
-          <div class="chip">Speed: <strong id="speed">1.0x</strong></div>
-          <div class="chip">Slow: <strong id="slow">0.0s</strong></div>
-          <div class="chip">HP: <strong id="hp">0</strong></div>
-        </div>
-      </header>
-      <div class="play">
-        <aside class="legend">
-          <div class="legend-title">Legend</div>
-          <div class="legend-item">
-            <canvas id="icon-apple" width="36" height="36"></canvas>
-            <div class="name">Apple</div>
-            <div class="desc">+1 score, grow by 1, slightly increases base speed.</div>
-          </div>
-          <div class="legend-item">
-            <canvas id="icon-banana" width="36" height="36"></canvas>
-            <div class="name">Banana</div>
-            <div class="desc">Temporarily slows speed; duration scales with high score (capped).</div>
-          </div>
-          <div class="legend-item">
-            <canvas id="icon-orange" width="36" height="36"></canvas>
-            <div class="name">Orange</div>
-            <div class="desc">+1 hitpoint up to a small maximum.</div>
-          </div>
-          <div class="legend-item">
-            <canvas id="icon-pear" width="36" height="36"></canvas>
-            <div class="name">Pear</div>
-            <div class="desc">Spawns in pairs; eating one teleports you to the other.</div>
-          </div>
-          <div class="legend-item">
-            <canvas id="icon-cherry" width="36" height="36"></canvas>
-            <div class="name">Cherry</div>
-            <div class="desc">Spawns on edges; when wrap is off: next move only, hit a wall to wrap once; otherwise just +1 score.</div>
-          </div>
-          <div class="legend-item">
-            <canvas id="icon-mouse" width="36" height="36"></canvas>
-            <div class="name">Mouse</div>
-            <div class="desc">Moves in 8 directions, avoids the snake, eats fruits; +5 if eaten.</div>
-          </div>
-          <div class="controls">
-            <div class="legend-title">Controls</div>
-            <div class="control-row">
-              <div class="kbdbar"><kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd></div>
-              <div class="desc">Move the snake. You cannot reverse into yourself.</div>
-            </div>
-            <div class="control-row">
-              <div class="kbdbar"><kbd>P</kbd></div>
-              <div class="desc">Pause / resume.</div>
-            </div>
-            <div class="control-row">
-              <div class="kbdbar"><kbd>R</kbd></div>
-              <div class="desc">Restart from the current start state.</div>
-            </div>
-            <div class="control-row">
-              <div class="kbdbar"><kbd>T</kbd></div>
-              <div class="desc">Toggle wrap-around walls.</div>
-            </div>
-          </div>
-        </aside>
-        <div class="board-wrap">
-          <canvas id="board" width="640" height="640" aria-label="Snake board" role="img"></canvas>
-        </div>
-      </div>
-      <div class="touchpad" aria-label="Touch controls">
-        <div class="dpad">
-          <div class="row">
-            <button class="btn" data-dir="up" aria-label="Up">▲</button>
-          </div>
-          <div class="row">
-            <button class="btn" data-dir="left" aria-label="Left">◀</button>
-            <button class="btn small" data-action="pause" aria-label="Pause/Resume">⏯</button>
-            <button class="btn" data-dir="right" aria-label="Right">▶</button>
-          </div>
-          <div class="row">
-            <button class="btn" data-dir="down" aria-label="Down">▼</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-<script type="module" src="./src/snake.js"></script>
-</body>
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Snake — Dark Mode (Canvas)</title>
+		<link rel="stylesheet" href="./styles.css" />
+	</head>
+	<body>
+		<div class="shell">
+			<div class="card">
+				<header>
+					<h1><span class="dot"></span> Snake</h1>
+					<div class="stats">
+						<button class="info-btn" id="infoHeaderBtn" aria-label="Info">ⓘ</button>
+						<button class="info-btn desktop-only" id="controlsHeaderBtn" aria-label="Controls">
+							⌨
+						</button>
+						<div class="chip">Score: <strong id="score">0</strong></div>
+						<div class="chip">High: <strong id="high">0</strong></div>
+						<div class="chip">Speed: <strong id="speed">1.0x</strong></div>
+						<div class="chip">Slow: <strong id="slow">0.0s</strong></div>
+						<div class="chip">HP: <strong id="hp">0</strong></div>
+					</div>
+				</header>
+				<div class="play">
+					<aside class="legend">
+						<div class="legend-title">Legend</div>
+						<div class="legend-item">
+							<canvas id="icon-apple" width="36" height="36"></canvas>
+							<div class="name">Apple</div>
+							<div class="desc">+1 score, grow by 1, slightly increases base speed.</div>
+						</div>
+						<div class="legend-item">
+							<canvas id="icon-banana" width="36" height="36"></canvas>
+							<div class="name">Banana</div>
+							<div class="desc">
+								Temporarily slows speed; duration scales with high score (capped).
+							</div>
+						</div>
+						<div class="legend-item">
+							<canvas id="icon-orange" width="36" height="36"></canvas>
+							<div class="name">Orange</div>
+							<div class="desc">+1 hitpoint up to a small maximum.</div>
+						</div>
+						<div class="legend-item">
+							<canvas id="icon-pear" width="36" height="36"></canvas>
+							<div class="name">Pear</div>
+							<div class="desc">Spawns in pairs; eating one teleports you to the other.</div>
+						</div>
+						<div class="legend-item">
+							<canvas id="icon-cherry" width="36" height="36"></canvas>
+							<div class="name">Cherry</div>
+							<div class="desc">
+								Spawns on edges; when wrap is off: next move only, hit a wall to wrap once;
+								otherwise just +1 score.
+							</div>
+						</div>
+						<div class="legend-item">
+							<canvas id="icon-mouse" width="36" height="36"></canvas>
+							<div class="name">Mouse</div>
+							<div class="desc">
+								Moves in 8 directions, avoids the snake, eats fruits; +5 if eaten.
+							</div>
+						</div>
+						<div class="controls">
+							<div class="legend-title">Controls</div>
+							<div class="control-row">
+								<div class="kbdbar">
+									<kbd data-action="up">W</kbd><kbd data-action="left">A</kbd><kbd
+										data-action="down"
+									>S</kbd><kbd data-action="right">D</kbd>
+								</div>
+								<div class="desc">Move the snake. You cannot reverse into yourself.</div>
+							</div>
+							<div class="control-row">
+								<div class="kbdbar"><kbd data-action="pause">P</kbd></div>
+								<div class="desc">Pause / resume.</div>
+							</div>
+							<div class="control-row">
+								<div class="kbdbar"><kbd data-action="restart">R</kbd></div>
+								<div class="desc">Restart from the current start state.</div>
+							</div>
+							<div class="control-row">
+								<div class="kbdbar"><kbd data-action="wrap">T</kbd></div>
+								<div class="desc">Toggle wrap-around walls.</div>
+							</div>
+						</div>
+					</aside>
+					<div class="board-wrap">
+						<canvas
+							id="board"
+							width="640"
+							height="640"
+							aria-label="Snake board"
+							role="img"
+						></canvas>
+					</div>
+				</div>
+				<div class="touchpad" aria-label="Touch controls">
+					<div class="dpad">
+						<div class="row">
+							<button class="btn" data-dir="up" aria-label="Up">▲</button>
+						</div>
+						<div class="row">
+							<button class="btn" data-dir="left" aria-label="Left">◀</button>
+							<button class="btn small" data-action="pause" aria-label="Pause/Resume">⏯</button>
+							<button class="btn" data-dir="right" aria-label="Right">▶</button>
+						</div>
+						<div class="row">
+							<button class="btn" data-dir="down" aria-label="Down">▼</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<script type="module" src="./src/snake.js"></script>
+	</body>
 </html>

--- a/snake_dark_canvas.html
+++ b/snake_dark_canvas.html
@@ -1,100 +1,119 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Snake — Dark Mode (Canvas)</title>
-  <link rel="stylesheet" href="./styles.css" />
-</head>
-<body>
-  <div class="shell">
-    <div class="card">
-      <header>
-        <h1><span class="dot"></span> Snake</h1>
-        <div class="stats">
-          <button class="info-btn" id="infoHeaderBtn" aria-label="Info">ⓘ</button>
-          <button class="info-btn desktop-only" id="controlsHeaderBtn" aria-label="Controls">⌨</button>
-          <div class="chip">Score: <strong id="score">0</strong></div>
-          <div class="chip">High: <strong id="high">0</strong></div>
-          <div class="chip">Speed: <strong id="speed">1.0x</strong></div>
-          <div class="chip">Slow: <strong id="slow">0.0s</strong></div>
-          <div class="chip">HP: <strong id="hp">0</strong></div>
-        </div>
-      </header>
-      <div class="play">
-        <aside class="legend">
-          <div class="legend-title">Legend</div>
-          <div class="legend-item">
-            <canvas id="icon-apple" width="36" height="36"></canvas>
-            <div class="name">Apple</div>
-            <div class="desc">+1 score, grow by 1, slightly increases base speed.</div>
-          </div>
-          <div class="legend-item">
-            <canvas id="icon-banana" width="36" height="36"></canvas>
-            <div class="name">Banana</div>
-            <div class="desc">Temporarily slows speed; duration scales with high score (capped).</div>
-          </div>
-          <div class="legend-item">
-            <canvas id="icon-orange" width="36" height="36"></canvas>
-            <div class="name">Orange</div>
-            <div class="desc">+1 hitpoint up to a small maximum.</div>
-          </div>
-          <div class="legend-item">
-            <canvas id="icon-pear" width="36" height="36"></canvas>
-            <div class="name">Pear</div>
-            <div class="desc">Spawns in pairs; eating one teleports you to the other.</div>
-          </div>
-          <div class="legend-item">
-            <canvas id="icon-cherry" width="36" height="36"></canvas>
-            <div class="name">Cherry</div>
-            <div class="desc">Spawns on edges; when wrap is off: next move only, hit a wall to wrap once; otherwise just +1 score.</div>
-          </div>
-          <div class="legend-item">
-            <canvas id="icon-mouse" width="36" height="36"></canvas>
-            <div class="name">Mouse</div>
-            <div class="desc">Moves in 8 directions, avoids the snake, eats fruits; +5 if eaten.</div>
-          </div>
-          <div class="controls">
-            <div class="legend-title">Controls</div>
-            <div class="control-row">
-              <div class="kbdbar"><kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd></div>
-              <div class="desc">Move the snake. You cannot reverse into yourself.</div>
-            </div>
-            <div class="control-row">
-              <div class="kbdbar"><kbd>P</kbd></div>
-              <div class="desc">Pause / resume.</div>
-            </div>
-            <div class="control-row">
-              <div class="kbdbar"><kbd>R</kbd></div>
-              <div class="desc">Restart from the current start state.</div>
-            </div>
-            <div class="control-row">
-              <div class="kbdbar"><kbd>T</kbd></div>
-              <div class="desc">Toggle wrap-around walls.</div>
-            </div>
-          </div>
-        </aside>
-        <div class="board-wrap">
-          <canvas id="board" width="640" height="640" aria-label="Snake board" role="img"></canvas>
-        </div>
-      </div>
-      <div class="touchpad" aria-label="Touch controls">
-        <div class="dpad">
-          <div class="row">
-            <button class="btn" data-dir="up" aria-label="Up">▲</button>
-          </div>
-          <div class="row">
-            <button class="btn" data-dir="left" aria-label="Left">◀</button>
-            <button class="btn small" data-action="pause" aria-label="Pause/Resume">⏯</button>
-            <button class="btn" data-dir="right" aria-label="Right">▶</button>
-          </div>
-          <div class="row">
-            <button class="btn" data-dir="down" aria-label="Down">▼</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-<script type="module" src="./src/snake.js"></script>
-</body>
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Snake — Dark Mode (Canvas)</title>
+		<link rel="stylesheet" href="./styles.css" />
+	</head>
+	<body>
+		<div class="shell">
+			<div class="card">
+				<header>
+					<h1><span class="dot"></span> Snake</h1>
+					<div class="stats">
+						<button class="info-btn" id="infoHeaderBtn" aria-label="Info">ⓘ</button>
+						<button class="info-btn desktop-only" id="controlsHeaderBtn" aria-label="Controls">
+							⌨
+						</button>
+						<div class="chip">Score: <strong id="score">0</strong></div>
+						<div class="chip">High: <strong id="high">0</strong></div>
+						<div class="chip">Speed: <strong id="speed">1.0x</strong></div>
+						<div class="chip">Slow: <strong id="slow">0.0s</strong></div>
+						<div class="chip">HP: <strong id="hp">0</strong></div>
+					</div>
+				</header>
+				<div class="play">
+					<aside class="legend">
+						<div class="legend-title">Legend</div>
+						<div class="legend-item">
+							<canvas id="icon-apple" width="36" height="36"></canvas>
+							<div class="name">Apple</div>
+							<div class="desc">+1 score, grow by 1, slightly increases base speed.</div>
+						</div>
+						<div class="legend-item">
+							<canvas id="icon-banana" width="36" height="36"></canvas>
+							<div class="name">Banana</div>
+							<div class="desc">
+								Temporarily slows speed; duration scales with high score (capped).
+							</div>
+						</div>
+						<div class="legend-item">
+							<canvas id="icon-orange" width="36" height="36"></canvas>
+							<div class="name">Orange</div>
+							<div class="desc">+1 hitpoint up to a small maximum.</div>
+						</div>
+						<div class="legend-item">
+							<canvas id="icon-pear" width="36" height="36"></canvas>
+							<div class="name">Pear</div>
+							<div class="desc">Spawns in pairs; eating one teleports you to the other.</div>
+						</div>
+						<div class="legend-item">
+							<canvas id="icon-cherry" width="36" height="36"></canvas>
+							<div class="name">Cherry</div>
+							<div class="desc">
+								Spawns on edges; when wrap is off: next move only, hit a wall to wrap once;
+								otherwise just +1 score.
+							</div>
+						</div>
+						<div class="legend-item">
+							<canvas id="icon-mouse" width="36" height="36"></canvas>
+							<div class="name">Mouse</div>
+							<div class="desc">
+								Moves in 8 directions, avoids the snake, eats fruits; +5 if eaten.
+							</div>
+						</div>
+						<div class="controls">
+							<div class="legend-title">Controls</div>
+							<div class="control-row">
+								<div class="kbdbar">
+									<kbd data-action="up">W</kbd><kbd data-action="left">A</kbd><kbd
+										data-action="down"
+									>S</kbd><kbd data-action="right">D</kbd>
+								</div>
+								<div class="desc">Move the snake. You cannot reverse into yourself.</div>
+							</div>
+							<div class="control-row">
+								<div class="kbdbar"><kbd data-action="pause">P</kbd></div>
+								<div class="desc">Pause / resume.</div>
+							</div>
+							<div class="control-row">
+								<div class="kbdbar"><kbd data-action="restart">R</kbd></div>
+								<div class="desc">Restart from the current start state.</div>
+							</div>
+							<div class="control-row">
+								<div class="kbdbar"><kbd data-action="wrap">T</kbd></div>
+								<div class="desc">Toggle wrap-around walls.</div>
+							</div>
+						</div>
+					</aside>
+					<div class="board-wrap">
+						<canvas
+							id="board"
+							width="640"
+							height="640"
+							aria-label="Snake board"
+							role="img"
+						></canvas>
+					</div>
+				</div>
+				<div class="touchpad" aria-label="Touch controls">
+					<div class="dpad">
+						<div class="row">
+							<button class="btn" data-dir="up" aria-label="Up">▲</button>
+						</div>
+						<div class="row">
+							<button class="btn" data-dir="left" aria-label="Left">◀</button>
+							<button class="btn small" data-action="pause" aria-label="Pause/Resume">⏯</button>
+							<button class="btn" data-dir="right" aria-label="Right">▶</button>
+						</div>
+						<div class="row">
+							<button class="btn" data-dir="down" aria-label="Down">▼</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<script type="module" src="./src/snake.js"></script>
+	</body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -238,17 +238,27 @@ button {
 	transition: transform 0.06s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 select {
-	padding: 10px 14px;
-	background: #0c1219;
-	border: 1px solid #1f2937;
-	border-radius: 10px;
-	color: #e6edf3;
-	font-weight: 600;
-	box-shadow: 0 4px 16px var(--shadow), inset 0 1px 0 #172033;
-	cursor: pointer;
+        padding: 10px 14px;
+        background: #0c1219;
+        border: 1px solid #1f2937;
+        border-radius: 10px;
+        color: #e6edf3;
+        font-weight: 600;
+        box-shadow: 0 4px 16px var(--shadow), inset 0 1px 0 #172033;
+        cursor: pointer;
+}
+#keyWrap {
+	margin-bottom: 8px;
+	display: grid;
+	grid-template-columns: auto auto;
+	gap: 6px 12px;
+	text-align: left;
+}
+#keyWrap button {
+	min-width: 40px;
 }
 button:hover {
-	transform: translateY(-1px);
+        transform: translateY(-1px);
 }
 button:active {
 	transform: translateY(1px);

--- a/styles.css
+++ b/styles.css
@@ -1,59 +1,346 @@
-:root { --bg: #0b0f14; --panel: #0f141b; --muted: #7b8794; --text: #e6edf3; --accent: #4ade80; --accent-2: #60a5fa; --danger: #f87171; --grid: #15202b; --shadow: #00000055; }
-* { box-sizing: border-box; }
-html, body { height: 100%; }
-body { margin: 0; overflow: hidden; background: radial-gradient(1200px 800px at 70% -200px, #10151d 0%, var(--bg) 60%) fixed; color: #e6edf3; font: 16px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Inter, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji"; display: grid; place-items: center; }
-.shell { width: 96vw; max-width: 100vw; margin: 16px auto; overflow: hidden; }
-.card { background: linear-gradient(180deg, #0f141b 0%, #0c1117 100%); border: 1px solid #1f2937; border-radius: 18px; box-shadow: 0 10px 30px var(--shadow), inset 0 1px 0 #1a2230; padding: 14px; height: calc(100vh - 24px); display: flex; flex-direction: column; overflow: hidden; }
-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; flex: 0 0 auto; padding-left: 0; }
-h1 { font-size: 18px; margin: 0; letter-spacing: 0.5px; color: #dbeafe; display: flex; align-items: center; gap: 10px; }
-h1 .dot { width: 10px; height: 10px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 8px var(--accent); display: inline-block; }
-.stats { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
-.chip { background: #0b1117; border: 1px solid #1f2937; padding: 6px 10px; border-radius: 999px; font-size: 13px; color: #7b8794; }
-.chip strong { color: #e6edf3; }
-.play { display: grid; grid-template-columns: 1fr; gap: 14px; align-items: stretch; min-height: 0; }
-.legend { display: none; }
-.legend-title { font-weight: 700; margin: 0 0 8px 0; font-size: 14px; letter-spacing: .3px; color: #dbeafe; }
-.legend-item { display: grid; grid-template-columns: 36px 1fr; grid-template-rows: auto auto; gap: 6px 10px; padding: 8px 6px; border-radius: 10px; align-items: center; }
-.legend-item canvas { width: 30px; height: 30px; border-radius: 8px; border: 1px solid #1f2937; background: #0c1219; }
-.legend-item .name { font-weight: 600; color: #e5e7eb; }
-.legend-item .desc { font-size: 12px; color: #94a3b8; grid-column: 1 / -1; }
-.controls { margin-top: 10px; padding-top: 10px; border-top: 1px dashed #1f2937; }
-.controls .desc { font-size: 12px; color: #94a3b8; }
-.control-row { display: grid; grid-template-columns: 1fr; gap: 4px; margin: 8px 0; }
-.kbdbar { display: inline-flex; gap: 4px; flex-wrap: wrap; }
-kbd { background: #0c1117; border: 1px solid #1f2937; border-radius: 6px; padding: 2px 6px; font-size: 12px; color: #cbd5e1; }
-.board-wrap { position: relative; flex: 1 1 auto; display: grid; place-items: center; min-height: 0; width: 100%; overflow: hidden; }
-canvas#board { display: block; background: radial-gradient(800px 600px at 50% 30%, #0f1621 0%, #0b1117 35%, #0a0f14 100%); border-radius: 14px; border: 1px solid #1f2937; touch-action: none; max-width: 100%; height: auto; }
+:root {
+	--bg: #0b0f14;
+	--panel: #0f141b;
+	--muted: #7b8794;
+	--text: #e6edf3;
+	--accent: #4ade80;
+	--accent-2: #60a5fa;
+	--danger: #f87171;
+	--grid: #15202b;
+	--shadow: #00000055;
+}
+* {
+	box-sizing: border-box;
+}
+html, body {
+	height: 100%;
+}
+body {
+	margin: 0;
+	overflow: hidden;
+	background: radial-gradient(1200px 800px at 70% -200px, #10151d 0%, var(--bg) 60%) fixed;
+	color: #e6edf3;
+	font:
+		16px/1.4 system-ui,
+		-apple-system,
+		Segoe UI,
+		Roboto,
+		Inter,
+		'Helvetica Neue',
+		Arial,
+		'Noto Sans',
+		'Apple Color Emoji',
+		'Segoe UI Emoji';
+	display: grid;
+	place-items: center;
+}
+.shell {
+	width: 96vw;
+	max-width: 100vw;
+	margin: 16px auto;
+	overflow: hidden;
+}
+.card {
+	background: linear-gradient(180deg, #0f141b 0%, #0c1117 100%);
+	border: 1px solid #1f2937;
+	border-radius: 18px;
+	box-shadow: 0 10px 30px var(--shadow), inset 0 1px 0 #1a2230;
+	padding: 14px;
+	height: calc(100vh - 24px);
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	margin-bottom: 12px;
+	flex: 0 0 auto;
+	padding-left: 0;
+}
+h1 {
+	font-size: 18px;
+	margin: 0;
+	letter-spacing: 0.5px;
+	color: #dbeafe;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+h1 .dot {
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	background: var(--accent);
+	box-shadow: 0 0 8px var(--accent);
+	display: inline-block;
+}
+.stats {
+	display: flex;
+	gap: 12px;
+	align-items: center;
+	flex-wrap: wrap;
+}
+.chip {
+	background: #0b1117;
+	border: 1px solid #1f2937;
+	padding: 6px 10px;
+	border-radius: 999px;
+	font-size: 13px;
+	color: #7b8794;
+}
+.chip strong {
+	color: #e6edf3;
+}
+.play {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 14px;
+	align-items: stretch;
+	min-height: 0;
+}
+.legend {
+	display: none;
+}
+.legend-title {
+	font-weight: 700;
+	margin: 0 0 8px 0;
+	font-size: 14px;
+	letter-spacing: 0.3px;
+	color: #dbeafe;
+}
+.legend-item {
+	display: grid;
+	grid-template-columns: 36px 1fr;
+	grid-template-rows: auto auto;
+	gap: 6px 10px;
+	padding: 8px 6px;
+	border-radius: 10px;
+	align-items: center;
+}
+.legend-item canvas {
+	width: 30px;
+	height: 30px;
+	border-radius: 8px;
+	border: 1px solid #1f2937;
+	background: #0c1219;
+}
+.legend-item .name {
+	font-weight: 600;
+	color: #e5e7eb;
+}
+.legend-item .desc {
+	font-size: 12px;
+	color: #94a3b8;
+	grid-column: 1 / -1;
+}
+.controls {
+	margin-top: 10px;
+	padding-top: 10px;
+	border-top: 1px dashed #1f2937;
+}
+.controls .desc {
+	font-size: 12px;
+	color: #94a3b8;
+}
+.control-row {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 4px;
+	margin: 8px 0;
+}
+.kbdbar {
+	display: inline-flex;
+	gap: 4px;
+	flex-wrap: wrap;
+}
+kbd {
+	background: #0c1117;
+	border: 1px solid #1f2937;
+	border-radius: 6px;
+	padding: 2px 6px;
+	font-size: 12px;
+	color: #cbd5e1;
+}
+.board-wrap {
+	position: relative;
+	flex: 1 1 auto;
+	display: grid;
+	place-items: center;
+	min-height: 0;
+	width: 100%;
+	overflow: hidden;
+}
+canvas#board {
+	display: block;
+	background: radial-gradient(800px 600px at 50% 30%, #0f1621 0%, #0b1117 35%, #0a0f14 100%);
+	border-radius: 14px;
+	border: 1px solid #1f2937;
+	touch-action: none;
+	max-width: 100%;
+	height: auto;
+}
 /* Overlay shells */
-.overlay { position: fixed; inset: 0; display: grid; place-items: center; pointer-events: none; z-index: 9999; padding: 12px; }
-.overlay.interactive { pointer-events: auto; }
-.overlay .panel { pointer-events: auto; background: rgba(8,11,15,0.82); backdrop-filter: blur(8px); border: 1px solid #1f2937; border-radius: 16px; padding: 18px 20px; text-align: center; width: 100%; max-width: min(560px, 92vw); max-height: calc(100dvh - 48px); overflow: auto; box-shadow: 0 10px 30px var(--shadow); }
-.title { font-weight: 700; letter-spacing: 0.4px; margin-bottom: 6px; }
-.subtitle { color: #7b8794; font-size: 14px; margin-bottom: 12px; }
-.btns { display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; }
-button { all: unset; padding: 10px 14px; background: #0c1219; border: 1px solid #1f2937; border-radius: 10px; cursor: pointer; color: #e6edf3; font-weight: 600; box-shadow: 0 4px 16px var(--shadow), inset 0 1px 0 #172033; transition: transform .06s ease, box-shadow .2s ease, background .2s ease; }
-button:hover { transform: translateY(-1px); }
-button:active { transform: translateY(1px); }
-.primary { background: linear-gradient(180deg, #1a2a1f, #0d1a12); border-color: #1f3b2a; }
-.danger { background: linear-gradient(180deg, #2a1a1a, #1a0d0d); border-color: #3b1f1f; }
-.info-btn { width: 42px; height: 42px; border-radius: 10px; font-size: 22px; display: grid; place-items: center; line-height: 1; }
-.desktop-only { display: inline-block; }
+.overlay {
+	position: fixed;
+	inset: 0;
+	display: grid;
+	place-items: center;
+	pointer-events: none;
+	z-index: 9999;
+	padding: 12px;
+}
+.overlay.interactive {
+	pointer-events: auto;
+}
+.overlay .panel {
+	pointer-events: auto;
+	background: rgba(8, 11, 15, 0.82);
+	backdrop-filter: blur(8px);
+	border: 1px solid #1f2937;
+	border-radius: 16px;
+	padding: 18px 20px;
+	text-align: center;
+	width: 100%;
+	max-width: min(560px, 92vw);
+	max-height: calc(100dvh - 48px);
+	overflow: auto;
+	box-shadow: 0 10px 30px var(--shadow);
+}
+.title {
+	font-weight: 700;
+	letter-spacing: 0.4px;
+	margin-bottom: 6px;
+}
+.subtitle {
+	color: #7b8794;
+	font-size: 14px;
+	margin-bottom: 12px;
+}
+.btns {
+	display: flex;
+	gap: 8px;
+	justify-content: center;
+	flex-wrap: wrap;
+}
+button {
+	all: unset;
+	padding: 10px 14px;
+	background: #0c1219;
+	border: 1px solid #1f2937;
+	border-radius: 10px;
+	cursor: pointer;
+	color: #e6edf3;
+	font-weight: 600;
+	box-shadow: 0 4px 16px var(--shadow), inset 0 1px 0 #172033;
+	transition: transform 0.06s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+select {
+	padding: 10px 14px;
+	background: #0c1219;
+	border: 1px solid #1f2937;
+	border-radius: 10px;
+	color: #e6edf3;
+	font-weight: 600;
+	box-shadow: 0 4px 16px var(--shadow), inset 0 1px 0 #172033;
+	cursor: pointer;
+}
+button:hover {
+	transform: translateY(-1px);
+}
+button:active {
+	transform: translateY(1px);
+}
+.primary {
+	background: linear-gradient(180deg, #1a2a1f, #0d1a12);
+	border-color: #1f3b2a;
+}
+.danger {
+	background: linear-gradient(180deg, #2a1a1a, #1a0d0d);
+	border-color: #3b1f1f;
+}
+.info-btn {
+	width: 42px;
+	height: 42px;
+	border-radius: 10px;
+	font-size: 22px;
+	display: grid;
+	place-items: center;
+	line-height: 1;
+}
+.desktop-only {
+	display: inline-block;
+}
 
 /* Touch controls (hidden on desktop) */
-.touchpad { display: none; margin-top: 10px; }
-.touchpad .dpad { display: grid; grid-template-rows: auto auto auto; gap: 10px; justify-content: center; }
-.touchpad .row { display: flex; gap: 10px; justify-content: center; }
-.touchpad .btn { all: unset; min-width: 64px; min-height: 64px; background: #0c1219; color: #e6edf3; border: 1px solid #1f2937; border-radius: 14px; display: grid; place-items: center; font-size: 24px; box-shadow: 0 4px 12px var(--shadow), inset 0 1px 0 #172033; touch-action: manipulation; }
-.touchpad .btn.small { min-width: 56px; min-height: 56px; font-size: 18px; }
-.touchpad .btn:active { transform: translateY(1px); }
+.touchpad {
+	display: none;
+	margin-top: 10px;
+}
+.touchpad .dpad {
+	display: grid;
+	grid-template-rows: auto auto auto;
+	gap: 10px;
+	justify-content: center;
+}
+.touchpad .row {
+	display: flex;
+	gap: 10px;
+	justify-content: center;
+}
+.touchpad .btn {
+	all: unset;
+	min-width: 64px;
+	min-height: 64px;
+	background: #0c1219;
+	color: #e6edf3;
+	border: 1px solid #1f2937;
+	border-radius: 14px;
+	display: grid;
+	place-items: center;
+	font-size: 24px;
+	box-shadow: 0 4px 12px var(--shadow), inset 0 1px 0 #172033;
+	touch-action: manipulation;
+}
+.touchpad .btn.small {
+	min-width: 56px;
+	min-height: 56px;
+	font-size: 18px;
+}
+.touchpad .btn:active {
+	transform: translateY(1px);
+}
 
 @media (max-width: 780px) {
-  .play { grid-template-columns: 1fr; }
-  .shell { width: 100vw; margin: 8px auto; }
-  .card { height: auto; min-height: calc(100vh - 16px); }
-  header { padding-left: 0; flex-wrap: wrap; gap: 8px; }
-  .stats { width: 100%; justify-content: space-between; }
-  .legend { display: none; }
-  .touchpad { display: block; }
-  .desktop-only { display: none; }
+	.play {
+		grid-template-columns: 1fr;
+	}
+	.shell {
+		width: 100vw;
+		margin: 8px auto;
+	}
+	.card {
+		height: auto;
+		min-height: calc(100vh - 16px);
+	}
+	header {
+		padding-left: 0;
+		flex-wrap: wrap;
+		gap: 8px;
+	}
+	.stats {
+		width: 100%;
+		justify-content: space-between;
+	}
+	.legend {
+		display: none;
+	}
+	.touchpad {
+		display: block;
+	}
+	.desktop-only {
+		display: none;
+	}
 }

--- a/tests/snake.test.js
+++ b/tests/snake.test.js
@@ -4,27 +4,38 @@ import { StorageService } from '../src/snake.js';
 
 /** Simple in-memory localStorage mock. */
 class MockLocalStorage {
-constructor() { this.store = {}; }
-getItem(key) { return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null; }
-setItem(key, value) { this.store[key] = String(value); }
-clear() { this.store = {}; }
+	constructor() { this.store = {}; }
+	getItem(key) { return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null; }
+	setItem(key, value) { this.store[key] = String(value); }
+	clear() { this.store = {}; }
 }
 
 globalThis.localStorage = new MockLocalStorage();
 
 function assertEquals(actual, expected) {
-if (actual !== expected) {
-throw new Error(`${actual} !== ${expected}`);
+	if (actual !== expected) {
+	throw new Error(`${actual} !== ${expected}`);
 }
 }
 
 Deno.test('StorageService stores high score and controls', () => {
-const storage = new StorageService();
+	const storage = new StorageService();
 
-storage.setHighScore(42);
-assertEquals(storage.getHighScore(), 42);
+	storage.setHighScore(42);
+	assertEquals(storage.getHighScore(), 42);
 
-const controls = { scheme: 'wasd', keys: { up: 'KeyW', left: 'KeyA', down: 'KeyS', right: 'KeyD', }, };
-storage.setControls(controls);
-assertEquals(JSON.stringify(storage.getControls()), JSON.stringify(controls));
+	const controls = {
+	scheme: 'wasd',
+	keys: {
+		up: 'KeyW',
+		left: 'KeyA',
+		down: 'KeyS',
+		right: 'KeyD',
+		pause: 'KeyP',
+		restart: 'KeyR',
+		wrap: 'KeyT',
+	},
+};
+	storage.setControls(controls);
+	assertEquals(JSON.stringify(storage.getControls()), JSON.stringify(controls));
 });


### PR DESCRIPTION
## Summary
- Replace radio buttons with themed dropdown for control schemes
- Always show key mapping list and auto-switch to custom when keys change
- Style select elements to match button theme

## Testing
- `deno lint`
- `deno test`


------
https://chatgpt.com/codex/tasks/task_e_68a12564e8c4832eba92fe8463f867a8